### PR TITLE
feat: add computed default values

### DIFF
--- a/packages/doc_widget_builder/lib/src/library.dart
+++ b/packages/doc_widget_builder/lib/src/library.dart
@@ -128,10 +128,6 @@ String? getDefaultValue(ParameterElement param) {
       (defaultComputedValue?.isNull == true ||
           defaultComputedValueCode != null);
 
-  print(
-    'paramToString: $paramToString, paramIsString: $paramIsString, defaultValueCode: $defaultValueCode, defaultComputedValue: $defaultComputedValue, defaultComputedValueCode: $defaultComputedValueCode',
-  );
-
   if (paramIsString) {
     final trimmedValueCode = {'\"', '\''}.contains(defaultValueCode?[0])
         ? defaultValueCode!.substring(1, defaultValueCode.length - 1)

--- a/packages/doc_widget_builder/lib/src/library.dart
+++ b/packages/doc_widget_builder/lib/src/library.dart
@@ -124,20 +124,26 @@ String? getDefaultValue(ParameterElement param) {
   final defaultComputedValueCode =
       _convertDartObjectToCode(param.computeConstantValue());
 
+  final isEvaluated = defaultComputedValue?.hasKnownValue == true &&
+      (defaultComputedValue?.isNull == true ||
+          defaultComputedValueCode != null);
+
+  print(
+    'paramToString: $paramToString, paramIsString: $paramIsString, defaultValueCode: $defaultValueCode, defaultComputedValue: $defaultComputedValue, defaultComputedValueCode: $defaultComputedValueCode',
+  );
+
   if (paramIsString) {
     final trimmedValueCode = {'\"', '\''}.contains(defaultValueCode?[0])
         ? defaultValueCode!.substring(1, defaultValueCode.length - 1)
         : defaultValueCode;
 
-    if (trimmedValueCode != defaultComputedValueCode &&
-        defaultComputedValue?.hasKnownValue == true) {
+    if (trimmedValueCode != defaultComputedValueCode && isEvaluated) {
       return "'$trimmedValueCode: \\'$defaultComputedValueCode\\''";
     } else {
       return defaultValueCode;
     }
   } else {
-    if (defaultValueCode != defaultComputedValueCode &&
-        defaultComputedValue?.hasKnownValue == true) {
+    if (defaultValueCode != defaultComputedValueCode && isEvaluated) {
       return "'$defaultValueCode: $defaultComputedValueCode'";
     } else {
       return "'$defaultValueCode'";

--- a/packages/doc_widget_builder/lib/src/library.dart
+++ b/packages/doc_widget_builder/lib/src/library.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
@@ -71,7 +72,10 @@ String generateLibrary(ClassElement element) {
 }
 
 String formatSnippet(
-    DartFormatter formatter, String code, ClassElement element) {
+  DartFormatter formatter,
+  String code,
+  ClassElement element,
+) {
   try {
     return "'''${formatter.format(code)}'''";
   } catch (e) {
@@ -92,11 +96,53 @@ void _generateParametersRequired(StringBuffer buffer, ParameterElement param) {
   );
 }
 
+String? _convertDartObjectToCode(DartObject? object) {
+  if (object == null) return null;
+  final values = [
+    object.toBoolValue(),
+    object.toIntValue(),
+    object.toDoubleValue(),
+    object.toFunctionValue(),
+    object.toListValue(),
+    object.toSetValue(),
+    object.toMapValue(),
+    object.toStringValue(),
+    object.toSymbolValue(),
+    object.toTypeValue(),
+  ];
+  return values
+      .firstWhere((element) => element != null, orElse: () => null)
+      ?.toString();
+}
+
 String? getDefaultValue(ParameterElement param) {
   final paramToString = param.type.getDisplayString(withNullability: true);
   final paramIsString = paramToString.contains('String');
-  final defaultValue = param.defaultValueCode;
-  return paramIsString ? defaultValue : "'$defaultValue'";
+  final defaultValueCode = param.defaultValueCode;
+
+  final defaultComputedValue = param.computeConstantValue();
+  final defaultComputedValueCode =
+      _convertDartObjectToCode(param.computeConstantValue());
+
+  if (paramIsString) {
+    final trimmedValueCode = {'\"', '\''}.contains(defaultValueCode?[0])
+        ? defaultValueCode!.substring(1, defaultValueCode.length - 1)
+        : defaultValueCode;
+
+    if (trimmedValueCode != defaultComputedValueCode &&
+        defaultComputedValue?.hasKnownValue == true) {
+      return "'$trimmedValueCode: \\'$defaultComputedValueCode\\''";
+    } else {
+      return defaultValueCode;
+    }
+  } else {
+    if (defaultValueCode != defaultComputedValueCode &&
+        defaultComputedValue?.hasKnownValue == true) {
+      return "'$defaultValueCode: $defaultComputedValueCode'";
+    } else {
+      return "'$defaultValueCode'";
+    }
+  }
 }
 
 String _getParametersString(ClassElement element) {
@@ -106,7 +152,8 @@ String _getParametersString(ClassElement element) {
     _generateParametersRequired(parametersBuffer, param);
     if (getDescription(param.name, element.fields) != null) {
       parametersBuffer.write(
-          "description: '${getDescription(param.name, element.fields)}',");
+        "description: '${getDescription(param.name, element.fields)}',",
+      );
     }
     if (param.defaultValueCode != null) {
       parametersBuffer.write('defaultValue: ${getDefaultValue(param)},');

--- a/packages/doc_widget_builder/test/source_gen.dart
+++ b/packages/doc_widget_builder/test/source_gen.dart
@@ -108,6 +108,34 @@ class DefaultValue extends StatelessWidget {
   Widget build(BuildContext context) => Text(title);
 }
 
+// Should contain property default
+@ShouldGenerate(r"defaultValue: 'kValue: \'default value title\''", contains: true)
+@docWidget
+class DefaultConstValue extends StatelessWidget {
+  static const kValue = 'default value title';
+
+  DefaultConstValue({this.title = kValue});
+
+  /// Title description
+  final String title;
+  @override
+  Widget build(BuildContext context) => Text(title);
+}
+
+// Should contain property default
+@ShouldGenerate(r"defaultValue: '_kValue: \'default value title\''", contains: true)
+@docWidget
+class DefaultPrivateConstValue extends StatelessWidget {
+  static const _kValue = 'default value title';
+
+  DefaultPrivateConstValue({this.title = _kValue});
+
+  /// Title description
+  final String title;
+  @override
+  Widget build(BuildContext context) => Text(title);
+}
+
 // Should contain named parameter
 @ShouldGenerate('isNamed: true,', contains: true)
 @docWidget

--- a/packages/doc_widget_builder/test/source_gen.dart
+++ b/packages/doc_widget_builder/test/source_gen.dart
@@ -109,7 +109,10 @@ class DefaultValue extends StatelessWidget {
 }
 
 // Should contain property default
-@ShouldGenerate(r"defaultValue: 'kValue: \'default value title\''", contains: true)
+@ShouldGenerate(
+  r"defaultValue: 'kValue: \'default value title\''",
+  contains: true,
+)
 @docWidget
 class DefaultConstValue extends StatelessWidget {
   static const kValue = 'default value title';
@@ -123,7 +126,10 @@ class DefaultConstValue extends StatelessWidget {
 }
 
 // Should contain property default
-@ShouldGenerate(r"defaultValue: '_kValue: \'default value title\''", contains: true)
+@ShouldGenerate(
+  r"defaultValue: '_kValue: \'default value title\''",
+  contains: true,
+)
 @docWidget
 class DefaultPrivateConstValue extends StatelessWidget {
   static const _kValue = 'default value title';
@@ -134,6 +140,39 @@ class DefaultPrivateConstValue extends StatelessWidget {
   final String title;
   @override
   Widget build(BuildContext context) => Text(title);
+}
+
+class ComplexData {
+  final String title;
+  final int version;
+
+  const ComplexData(this.title, this.version);
+}
+
+@ShouldGenerate(r"defaultValue: 'kValue'", contains: true)
+@docWidget
+class DefaultConstComplexValue extends StatelessWidget {
+  static const kValue = ComplexData('default value title', 1);
+
+  DefaultConstComplexValue({this.data = kValue});
+
+  /// Title description
+  final ComplexData data;
+  @override
+  Widget build(BuildContext context) => Text(data.title);
+}
+
+@ShouldGenerate(r"defaultValue: 'kValue: null'", contains: true)
+@docWidget
+class DefaultConstComplexNullValue extends StatelessWidget {
+  static const ComplexData? kValue = null;
+
+  DefaultConstComplexNullValue({this.data = kValue});
+
+  /// Title description
+  final ComplexData? data;
+  @override
+  Widget build(BuildContext context) => Text(data?.title ?? '');
 }
 
 // Should contain named parameter


### PR DESCRIPTION
In our project we use constants values for constructor parameters.

This PR makes possible to see what value of constant passed to constructor parameter.

Unluckily it can't handle complex objects passed to parameter due to limitations of `DartObject`.

Example:

```dart
@docWidget
class DefaultConstValue extends StatelessWidget {
  static const kValue = 'default value title';

  DefaultConstValue({this.title = kValue});

  /// Title description
  final String title;
  @override
  Widget build(BuildContext context) => Text(title);
}
```

`PropertyDoc` will result in:

```dart
PropertyDoc(
  name: 'title',
  isRequired: false,
  isNamed: true,
  type: 'String',
  defaultValue: 'kValue: \'default value title\'',
)
```