### PR TITLE
feat: add deprecation label for deprecated widgets

### DIFF
--- a/packages/doc_widget/example/lib/doc_widget.dart
+++ b/packages/doc_widget/example/lib/doc_widget.dart
@@ -26,6 +26,7 @@ void main() {
     document: ButtonDocWidget(),
     previews: [
       WidgetPreview(
+        // ignore: deprecated_member_use_from_same_package
         widget: Button(
           'Button',
           // ignore: avoid_print

--- a/packages/doc_widget/example/lib/src/widgets/button.dart
+++ b/packages/doc_widget/example/lib/src/widgets/button.dart
@@ -8,6 +8,7 @@ import 'package:doc_widget_annotation/doc_widget_annotation.dart';
 /// );
 /// ```
 @docWidget
+@Deprecated('Use [ElevatedButton] instead.')
 class Button extends StatelessWidget {
   Button(
     this.text, {

--- a/packages/doc_widget/example/lib/src/widgets/button.doc_widget.dart
+++ b/packages/doc_widget/example/lib/src/widgets/button.doc_widget.dart
@@ -13,6 +13,8 @@ class ButtonDocWidget implements Documentation {
   @override
   bool get hasState => false;
   @override
+  String? get deprecation => 'Use [ElevatedButton] instead.';
+  @override
   List<PropertyDoc> get properties => [
         PropertyDoc(
           name: 'text',

--- a/packages/doc_widget/example/lib/src/widgets/heading.doc_widget.dart
+++ b/packages/doc_widget/example/lib/src/widgets/heading.doc_widget.dart
@@ -13,6 +13,8 @@ class HeadingDocWidget implements Documentation {
   @override
   bool get hasState => false;
   @override
+  String? get deprecation => null;
+  @override
   List<PropertyDoc> get properties => [
         PropertyDoc(
           name: 'title',

--- a/packages/doc_widget/lib/src/elements.dart
+++ b/packages/doc_widget/lib/src/elements.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 abstract class Documentation {
   String get name;
   List<PropertyDoc> get properties;
+  String? get deprecation;
   bool get hasState;
   String get snippet;
 }

--- a/packages/doc_widget/lib/src/widgets/item.dart
+++ b/packages/doc_widget/lib/src/widgets/item.dart
@@ -1,5 +1,6 @@
 import 'package:doc_widget/src/elements.dart';
 import 'package:flutter/widgets.dart';
+import 'package:doc_widget/src/widgets/item_deprecation.dart';
 import 'package:doc_widget/src/widgets/item_preview.dart';
 import 'package:doc_widget/src/widgets/item_properties.dart';
 import 'package:doc_widget/src/widgets/item_snippet.dart';
@@ -13,6 +14,8 @@ class Item extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        if (element.document.deprecation != null)
+          ItemDeprecation(message: element.document.deprecation!),
         ItemProperties(element.document),
         ItemPreview(element.previews),
         if (element.document.snippet.isNotEmpty)

--- a/packages/doc_widget/lib/src/widgets/item_deprecation.dart
+++ b/packages/doc_widget/lib/src/widgets/item_deprecation.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class ItemDeprecation extends StatelessWidget {
+  final String message;
+
+  const ItemDeprecation({Key? key, required this.message}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12.0),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(22.5),
+          color: Colors.amber.withOpacity(.15),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+          child: Text(
+            'Deprecated: $message',
+            style: TextStyle(
+              color: Colors.yellow.shade900.withOpacity(.9),
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/doc_widget_builder/test/source_gen.dart
+++ b/packages/doc_widget_builder/test/source_gen.dart
@@ -68,6 +68,21 @@ class _HasStateState extends State<HasState> {
   Widget build(BuildContext context) => Container();
 }
 
+// Check isDeprecated
+@ShouldGenerate(
+  r'''
+  @override
+  String? get deprecation => 'Use [NotDeprecatedWidget]';
+  ''',
+  contains: true,
+)
+@docWidget
+@Deprecated('Use [NotDeprecatedWidget]')
+class DeprecatedWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => const Text('Test');
+}
+
 // Should contain snippet
 @ShouldGenerate('final title = Title5()', contains: true)
 
@@ -216,6 +231,8 @@ class MoreProperties extends StatelessWidget {
   '  String get name => \'FullExample\';\n'
   '  @override\n'
   '  bool get hasState => false;\n'
+  '  @override\n'
+  '  String? get deprecation => null;\n'
   '  @override\n'
   '  List<PropertyDoc> get properties => [\n'
   '        PropertyDoc(\n'


### PR DESCRIPTION
This PR adds deprecation label in element preview.

Probably `doc_widget_builder` and `doc_widget` should be released together and be version constrained.

<details>
  <summary><h3>Screenshot</h3> (<i>click to expand</i>)</summary>

  <img src="https://i.ibb.co/gzLLJ4W/Simulator-Screen-Shot-i-Phone-13-2022-04-27-at-17-54-17.png" alt="Simulator-Screen-Shot-i-Phone-13-2022-04-27-at-17-54-17" border="0">
</details>